### PR TITLE
feat: Attach context in breadcrumb custom data automatically

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -17,13 +17,13 @@
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.138",
-        "raygun": "^1.0.0"
+        "raygun": "^1.1.0"
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.138",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.138.tgz",
-      "integrity": "sha512-71EHMl70TPWIAsFuHd85NHq6S6T2OOjiisPTrH7RgcjzpJpPh4RQJv7PvVvIxc6PIp8CLV7F9B+TdjcAES5vcA==",
+      "version": "8.10.140",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.140.tgz",
+      "integrity": "sha512-4Dh3dk2TUcbdfHrX0Al90mNGJDvA9NBiTQPzbrjGi/dLxzKCGOYgT8YQ47jUKNFALkAJAadifq0pzyjIUlhVhg==",
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -82,9 +82,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "version": "20.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
+      "integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -153,9 +153,9 @@
       "license": "MIT"
     },
     "node_modules/raygun": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/raygun/-/raygun-1.0.0.tgz",
-      "integrity": "sha512-WTlZzeux1BZq1FiGk/4fApwwd1dO87atV2WIEP5oYHYA1M5qhQ33qo4YeipZFKLj1rw2fjr+5CNZx0k53+C4kw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/raygun/-/raygun-1.1.0.tgz",
+      "integrity": "sha512-W0Og3ZgFnvApXWvtchkjsaboNsp821kW85ElZekOB8rZID2tJ0f6D9mGRSbok2AbG+OxNlkaHB1NxdTIMVfjCg==",
       "dependencies": {
         "@types/express": "^4.17.21",
         "debug": "^4.3.4",

--- a/example/prepare.sh
+++ b/example/prepare.sh
@@ -3,9 +3,16 @@
 # Save the current directory
 original_dir=$(pwd)
 
+# Ensure installation is up to date
+echo "Delete node_modules..."
+rm -fr node_modules
+echo "...done!"
+echo
+
 # Build the AWS Lambda package
 echo "Building @raygun.io/aws-lambda package..."
 cd .. || exit
+rm -fr node_modules
 npm install > /dev/null
 cd "$original_dir" || exit
 echo "...done!"

--- a/lib/raygun.aws.ts
+++ b/lib/raygun.aws.ts
@@ -1,7 +1,6 @@
 import { Client } from "raygun";
 import { Context, Handler } from "aws-lambda";
 import { runWithBreadcrumbsAsync } from "raygun/build/raygun.breadcrumbs";
-import {CustomData} from "raygun/build/types";
 
 export type AwsHandlerConfig = {
   client: Client;

--- a/lib/raygun.aws.ts
+++ b/lib/raygun.aws.ts
@@ -36,14 +36,12 @@ async function runHandler<TEvent, TResult>(
   context: Context,
   asyncHandler: AsyncHandler<TEvent, TResult>,
 ) {
-  awsHandlerConfig.client.addBreadcrumb(
-    {
-      message: `Running AWS Function: ${context.functionName}`,
-      customData: context,
-      level: "info",
-      category: "AWS Handler",
-    }
-  );
+  awsHandlerConfig.client.addBreadcrumb({
+    message: `Running AWS Function: ${context.functionName}`,
+    customData: context,
+    level: "info",
+    category: "AWS Handler",
+  });
 
   try {
     // Call to original handler and return value

--- a/lib/raygun.aws.ts
+++ b/lib/raygun.aws.ts
@@ -1,6 +1,7 @@
 import { Client } from "raygun";
 import { Context, Handler } from "aws-lambda";
 import { runWithBreadcrumbsAsync } from "raygun/build/raygun.breadcrumbs";
+import {CustomData} from "raygun/build/types";
 
 export type AwsHandlerConfig = {
   client: Client;
@@ -37,7 +38,12 @@ async function runHandler<TEvent, TResult>(
   asyncHandler: AsyncHandler<TEvent, TResult>,
 ) {
   awsHandlerConfig.client.addBreadcrumb(
-    `Running AWS Function: ${context.functionName}`,
+    {
+      message: `Running AWS Function: ${context.functionName}`,
+      customData: context,
+      level: "info",
+      category: "AWS Handler",
+    }
   );
 
   try {

--- a/test/raygun_aws_test.js
+++ b/test/raygun_aws_test.js
@@ -158,6 +158,7 @@ test("include scoped breadcrumbs", async function (t) {
   t.equal(message.details.breadcrumbs.length, 2);
   // internal breadcrumb
   t.equal(message.details.breadcrumbs[0].message, "Running AWS Function: test");
+  t.equal(message.details.breadcrumbs[0].customData.functionName, "test");
   // custom breadcrumb
   t.equal(message.details.breadcrumbs[1].message, "custom breadcrumb");
 });


### PR DESCRIPTION
## feat: Attach context in breadcrumb custom data automatically

### Description :memo:
- **Purpose**: Add breadcrumb that includes all AWS function Context automatically
- **Approach**: Extend existing breadcrumb to add custom data.

As discussed in #20 this PR adds the functionality to attach relevant info to error report as breadcrumbs.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Updates**

- Modify add breadcrumb call.
- Improve tests.
- Update example

### Test plan :test_tube:

- Unit tests.
- Check end-to-end

Breadcrumb attached

![image](https://github.com/MindscapeHQ/raygun4node-aws-lambda/assets/2494376/4677afe9-b2ae-4942-b25d-8f7420b93685)

### Author to check :eyeglasses:
- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested 
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [x] Project and all contained modules builds successfully
- [x] Change has been dev-/reviewer-tested, where possible
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)