### PR TITLE
chore: Prepare release 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.0.3
+
+- docs: Update README.md (#38) (2024-07-16
+- ci: Set dependabot interval to "monthly" (#44) (2024-07-22)
+- chore(deps-dev): bump @eslint/js from 9.6.0 to 9.10.0 (#58) (2024-09-12)
+- chore(deps-dev): bump @types/node from 20.14.10 to 22.5.1 (#57) (2024-09-12)
+- chore(deps): bump @types/aws-lambda from 8.10.141 to 8.10.145 (#56) (2024-09-12)
+- chore(deps): bump raygun from 1.2.0 to 2.0.0 (#47) (2024-09-12)
+- chore(deps-dev): bump typescript from 5.5.2 to 5.5.3 (#43) (2024-07-18)
+- chore(deps): bump raygun from 1.1.0 to 1.2.0 (#42) (2024-07-18)
+- chore(deps): bump @types/aws-lambda from 8.10.140 to 8.10.141 (#41) (2024-07-18)
+- chore(deps-dev): bump tap from 19.2.5 to 21.0.0 (#40) (2024-07-18)
+- chore(deps-dev): bump prettier from 3.3.2 to 3.3.3 (#39) (2024-07-18)
+
 ## 0.0.2
 
 - feat: Attach context in breadcrumb custom data automatically (#21)

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,189 +11,31 @@
         "@raygun.io/aws-lambda": "file:../"
       }
     },
-    "node_modules/@raygun.io/aws-lambda": {
-      "version": "0.0.1",
-      "resolved": "file:..",
+    "..": {
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.138",
-        "raygun": "^1.1.0"
-      }
-    },
-    "node_modules/@types/aws-lambda": {
-      "version": "8.10.140",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.140.tgz",
-      "integrity": "sha512-4Dh3dk2TUcbdfHrX0Al90mNGJDvA9NBiTQPzbrjGi/dLxzKCGOYgT8YQ47jUKNFALkAJAadifq0pzyjIUlhVhg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "20.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.6.tgz",
-      "integrity": "sha512-JbA0XIJPL1IiNnU7PFxDXyfAwcwVVrOoqyzzyQTyMeVhBzkJVMSkC1LlVsRQ2lpqiY4n6Bb9oCS6lzDKVQxbZw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
+        "raygun": "^2.0.0"
       },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "devDependencies": {
+        "@eslint/js": "^9.5.0",
+        "@stylistic/eslint-plugin": "^2.0.0",
+        "@stylistic/eslint-plugin-ts": "^2.2.1",
+        "@types/node": "^22.5.1",
+        "eslint": "^8.57.0",
+        "express": "^4.19.2",
+        "http-terminator": "^3.2.0",
+        "prettier": "^3.3.2",
+        "tap": "^21.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5",
+        "typescript-eslint": "^7.13.1"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
-    },
-    "node_modules/object-to-human-string": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-to-human-string/-/object-to-human-string-0.0.3.tgz",
-      "integrity": "sha512-DzEn44bSVfCg/0ToqTjXF9DPG3ZBo4TTwaD8IeLVonpt8IolvTlpXD7hXRoZRQp00LqYMxXHvMmav6jlcHDCNw==",
-      "license": "MIT"
-    },
-    "node_modules/raygun": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/raygun/-/raygun-1.1.0.tgz",
-      "integrity": "sha512-W0Og3ZgFnvApXWvtchkjsaboNsp821kW85ElZekOB8rZID2tJ0f6D9mGRSbok2AbG+OxNlkaHB1NxdTIMVfjCg==",
-      "dependencies": {
-        "@types/express": "^4.17.21",
-        "debug": "^4.3.4",
-        "object-to-human-string": "0.0.3",
-        "stack-trace": "0.0.10",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+    "node_modules/@raygun.io/aws-lambda": {
+      "resolved": "..",
+      "link": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raygun.io/aws-lambda",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raygun.io/aws-lambda",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.138",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raygun.io/aws-lambda",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Raygun Crash Reporting for AWS Lambda functions",
   "main": "build/raygun.aws.js",
   "types": "build/raygun.aws.d.ts",


### PR DESCRIPTION
Preparing for release 0.0.3 of the AWS Lambda provider

Release contains mostly dependencies, the important change is switching to Raygun4node 2.0.0

See CHANGELOG for list of changes.

`package-lock.json` changes are due to running `npm install` after the version change.

Also resolves https://github.com/MindscapeHQ/raygun4node-aws-lambda/issues/53