### PR TITLE
chore: Release 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.0.7
+
+- chore(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 (#164) (2026-04-01)
+- chore(deps-dev): bump typescript-eslint from 8.56.1 to 8.58.0 (#165) (2026-04-01)
+- chore(deps): bump raygun from 2.2.4 to 2.2.5 (#166) (2026-04-01)
+- chore(deps-dev): bump @types/node from 25.3.3 to 25.5.0 (#167) (2026-04-01)
+- chore(deps-dev): bump eslint from 9.39.2 to 10.1.0 (#168) (2026-04-01)
+- chore(deps-dev): bump @eslint/js from 9.39.2 to 10.0.1 (#161) (2026-04-01)
+- chore: complete ESLint 10 config cleanup and unify stylistic plugins (#169) (2026-04-04)
+- chore(deps): bump actions/checkout from 6 to 7 (#175) (2026-07-22)
+- chore(ci): make quality checks non-mutating (#176) (2026-07-23)
+- chore(deps): refresh dependency lockfiles (#177) (2026-07-23)
+
 ## 0.0.6
 
 - chore(deps-dev): bump eslint-plugin-tsdoc from 0.5.0 to 0.5.2 (#162) (2026-03-01)

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -13,7 +13,7 @@
     },
     "..": {
       "name": "@raygun.io/aws-lambda",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.160",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raygun.io/aws-lambda",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raygun.io/aws-lambda",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.160",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raygun.io/aws-lambda",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Raygun Crash Reporting for AWS Lambda functions",
   "main": "build/raygun.aws.js",
   "types": "build/raygun.aws.d.ts",


### PR DESCRIPTION
## Summary

- bump `@raygun.io/aws-lambda` and lockfile metadata from `0.0.6` to `0.0.7`
- update the example lockfile's linked provider metadata
- add the complete changelog for changes merged since `v0.0.6`

This is a maintenance release containing dependency, CI, and tooling updates. It does not change the provider source or public API behavior.

## Validation

- `npm install` (including TypeScript compilation)
- `npm test` — 13 assertions passed
- `npm run eslint`
- `npm run tseslint`
- `npm run prettier:check`
- `npm audit` — 0 vulnerabilities
- `npm audit --omit=dev` — 0 vulnerabilities
- example `npm ci`
- example full and production audits — 0 vulnerabilities
- example local handler invocation — `all good!`
- `npm publish --dry-run --json` — succeeded
  - package: `@raygun.io/aws-lambda@0.0.7`
  - 29 files (same as `0.0.6`)
  - 110,101 bytes packed / 156,962 bytes unpacked

GitHub Dependabot currently reports 0 open alerts.

## Release order

Per `RELEASING.md`, after this PR is approved and green:

1. Publish `@raygun.io/aws-lambda@0.0.7` to npm from this branch.
2. Verify the published version and dist tag.
3. Squash-merge this PR.
4. Create GitHub release/tag `v0.0.7` at the exact squash-merge commit.