### PR TITLE
chore: Release 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.0.8
+
+- Maintenance-only release; no public API or runtime behavior changes.
+- chore(deps): bump actions/setup-node from 6 to 7 (#179) (2026-08-04)
+- chore(deps-dev): bump tap from 21.7.4 to 21.7.5 (#181) (2026-08-04)
+- chore(deps-dev): bump eslint from 10.7.0 to 10.8.0 (#183) (2026-08-04)
+- chore(deps-dev): bump @types/node from 25.9.5 to 26.1.2 (#180) (2026-08-04)
+- chore(deps-dev): remediate transitive audit warnings (#184) (2026-08-04)
+- chore(deps-dev): align TypeScript 6 while preserving ES5 CommonJS output (#185) (2026-08-04)
+
 ## 0.0.7
 
 - chore(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 (#164) (2026-04-01)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raygun.io/aws-lambda",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raygun.io/aws-lambda",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@types/aws-lambda": "^8.10.160",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raygun.io/aws-lambda",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Raygun Crash Reporting for AWS Lambda functions",
   "main": "build/raygun.aws.js",
   "types": "build/raygun.aws.d.ts",


### PR DESCRIPTION
## Summary

- bump `@raygun.io/aws-lambda` from 0.0.7 to 0.0.8
- document the CI, test, lint, type-definition, and development lockfile maintenance included since 0.0.7
- document the TypeScript 6 alignment, which preserves the existing ES5 CommonJS output
- clarify that this maintenance release does not change the public API or runtime behavior

## Release classification

Patch release. The included updates affect development tooling, CI, type definitions, and development dependency lockfiles only. The TypeScript 6 compiler migration was independently verified to produce byte-for-byte identical JavaScript and declarations.

The runtime dependency remains `raygun: ^2.2.4`; this already admits 2.2.8 and avoids introducing an unnecessary minimum-version requirement.

## Validation

- `npm test` (13 passing)
- `npm run eslint`
- `npm run tseslint`
- `npm run prettier:check`
- `npm audit` (0 vulnerabilities)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm publish --dry-run` (`@raygun.io/aws-lambda@0.0.8`, 29 files)

## Release workflow

After approval, green CI, and publication of core `raygun@2.2.8`, publish `@raygun.io/aws-lambda@0.0.8` to npm before merging this PR, then create GitHub release `v0.0.8` from the merged release commit as documented in `RELEASING.md`.
